### PR TITLE
APIとテストに変更がなければ、常に同じドキュメントを生成できるようにしたい

### DIFF
--- a/lib/Test/JsonAPI/Autodoc/Request.pm
+++ b/lib/Test/JsonAPI/Autodoc/Request.pm
@@ -25,7 +25,7 @@ sub parse {
 
     my $is_json = 0;
     if ($content_type =~ m!^application/json!) {
-        $body = to_json(from_json($req->decoded_content), { pretty => 1 });
+        $body = to_json(from_json($req->decoded_content), { pretty => 1, canonical => 1 });
         $is_json = 1;
     }
 


### PR DESCRIPTION
jenkinsでのテストの成功時に自動でドキュメントを生成し、差分があればcommitするということをやりたいと考えているのですが、
apiの側でjsonのソートを事前に行わない限り、テストを実行するたびにjsonの要素の順番が違うだけの意味のない差分が生まれてしまい困っています。

Test::JsonApi::Autodocの側で考慮して欲しいと感じたので、
Test::JsonAPI::Autodoc::Request#parseでのto_jsonの呼び出しの際に、canonicalを指定し、apiが同じ意味のjsonを返すのならば、
常に同じドキュメントが作成できるようにしました。
