### PR TITLE
APIとテストに変更がなければ、常に同じドキュメントを生成できるようにしたい(訂正版

### DIFF
--- a/lib/Test/JsonAPI/Autodoc/Response.pm
+++ b/lib/Test/JsonAPI/Autodoc/Response.pm
@@ -17,7 +17,7 @@ sub parse {
     my $body         = $res->content;
     my $content_type = $res->content_type;
     if ($content_type =~ m!^application/json!) {
-        $body = to_json(from_json($res->decoded_content), { pretty => 1 });
+        $body = to_json(from_json($res->decoded_content), { pretty => 1, canonical => 1 });
     }
 
     return {

--- a/t/14_output_same_document.t
+++ b/t/14_output_same_document.t
@@ -1,0 +1,108 @@
+#!perl
+
+use strict;
+use warnings;
+use utf8;
+use HTTP::Request::Common;
+use Path::Tiny;
+use Plack::Test;
+use Plack::Request;
+
+use Test::More;
+use Test::JsonAPI::Autodoc;
+
+BEGIN {
+    $ENV{TEST_JSONAPI_AUTODOC} = 1;
+}
+
+my $app = sub {
+    my $env = shift;
+    my $req = Plack::Request->new($env);
+    return [
+        200,
+        [ 'Content-Type' => 'application/json' ],
+        [
+            '{
+                "hoge": {
+                    "a": "aa",
+                    "b": "bb"
+                }
+            }'
+        ],
+        ['{ "message" : "success" }']
+    ];
+};
+
+my $tempdir = Path::Tiny->tempdir('test-jsonapi-autodoc-XXXXXXXX');
+set_documents_path($tempdir);
+
+my $sample_doc = do { local $/; <DATA> };
+my $expected;
+for (1..50) {
+    test_psgi $app, sub {
+        my $cb = shift;
+
+        describe 'POST /' => sub {
+            my $req = POST '/';
+            $req->header('Content-Type' => 'application/json');
+            $req->content(q{
+                {
+                    "id": 1,
+                    "message": "blah blah"
+                }
+            });
+            plack_ok($cb, $req, 200, "get message ok");
+        };
+    };
+
+    $expected .= $sample_doc;
+}
+
+(my $filename = path($0)->basename) =~ s/\.t$//;
+$filename .= ".md";
+my $fh = path("$tempdir/$filename")->openr_utf8;
+
+chomp (my $generated_at_line = <$fh>);
+<$fh>; # blank
+my $got = do { local $/; <$fh> };
+is $got, $expected, 'result ok';
+
+done_testing;
+
+__DATA__
+## POST /
+
+get message ok
+
+### Target Server
+
+http://localhost
+
+(Plack application)
+
+### Parameters
+
+__application/json__
+
+- `id`: Number (e.g. 1)
+- `message`: String (e.g. "blah blah")
+
+### Request
+
+POST /
+
+### Response
+
+- Status:       200
+- Content-Type: application/json
+
+```json
+{
+   "hoge" : {
+      "a" : "aa",
+      "b" : "bb"
+   }
+}
+
+```
+


### PR DESCRIPTION
変更に誤りがあったので、いったん閉じさせていただいた以下のpull requestに書いていた通りです。
https://github.com/moznion/Test-JsonAPI-Autodoc/pull/20

Test::JsonAPI::Autodoc::Responseのjsonの生成部分にcanonicalを指定しました。以下の箇所です。
https://github.com/moznion/Test-JsonAPI-Autodoc/blob/master/lib/Test/JsonAPI/Autodoc/Response.pm#L20

50回同じドキュメントを生成してみて、すべて中身が同じであったか確認するテストも作成しました。

仮に今回の修正部分が壊れても、稀にテストが通ってしまうこともある(たまたま50回連続で同じ要素順でjsonが生成された場合)のですが、性質上仕方がないかなと思っています。

何もテストないよりはましかなと.....

